### PR TITLE
Move Hotspots to use GitHub packages.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "hotspots",
-  "version": "1.0.0",
+  "name": "@rockabox/hotspots",
+  "version": "2.0.0",
   "description": "Hotspots generation library",
   "main": "lib/hotspots.ts",
   "scripts": {
@@ -45,5 +45,8 @@
     "typescript": "~2.1.6",
     "typings": "~0.6.7",
     "webpack": "~2.2.1"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
   }
 }


### PR DESCRIPTION
- Name must be prefixed with `@rockabox`
- Add Github npm packages registry for publish config
- Update version to v2 as complete moving package.

**JIRA**
https://rockabox.atlassian.net/browse/RIG-4210

**Dependencies**
Auxilium.js: https://github.com/rockabox/Auxilium.js/pull/89
Hotspots: https://github.com/rockabox/hotspots/pull/2